### PR TITLE
fix howler.js url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/GoodBoyDigital/pixi.js.git
 [submodule "resources/public/vendor/js/howler.js"]
 	path = resources/public/vendor/js/howler.js
-	url = git@github.com:goldfire/howler.js.git
+	url = https://github.com/goldfire/howler.js.git


### PR DESCRIPTION
fixes error from:

$ git clone --recursive https://github.com/phelanm/chocolatier.git
...
Submodule 'resources/public/vendor/js/stats.js' (https://github.com/mrdoob/stats.js.git) registered for path 'resources/public/vendor/js/stats.js'
Cloning into 'resources/public/vendor/js/howler.js'...
Permission denied (publickey).
fatal: Could not read from remote repository.
...
