### PR TITLE
Update lein-figwheel to 0.5.18

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
                  [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]]
 
   :plugins [[lein-cljsbuild "1.1.7" :exclusions [org.clojure/clojurescript]]
-            [lein-figwheel "0.5.16" :exclusions [org.clojure/clojurescript]]
+            [lein-figwheel "0.5.18" :exclusions [org.clojure/clojurescript]]
             [cider/cider-nrepl "0.21.0"]
             [refactor-nrepl "2.4.0"]]
 


### PR DESCRIPTION
`lein figwheel` failed with this in dev branch HEAD.

```
Figwheel version mismatch!!
You are using the lein-figwheel plugin with version: "0.5.16"
With a figwheel-sidecar library with version:        "0.5.18"

These versions need to be the same.
```

Minimal fix is to update lein-figwheel to 0.5.18